### PR TITLE
Add rounding to optimizers

### DIFF
--- a/orbiteer/optimizers/base.py
+++ b/orbiteer/optimizers/base.py
@@ -3,6 +3,8 @@
 import typing as t
 from abc import ABC, abstractmethod
 
+from typing_extensions import Literal
+
 
 class AbstractOptimizer(ABC):
     """
@@ -15,18 +17,21 @@ class AbstractOptimizer(ABC):
         first_value: float,
         max_value: t.Optional[float] = None,
         min_value: t.Optional[float] = None,
+        round_places: t.Union[int, Literal[False]] = 0,
     ) -> None:
         self.goal = goal
         self.max_value = max_value
         self.min_value = min_value
         self.outputs = [first_value]
+        self.round_places = round_places
 
     def compute_next(self, measurement: t.Optional[float]) -> float:
         if measurement is None:
             return self.outputs[0]
 
         next_value = self._compute_next(measurement)
-        next_value = self.limit_value(next_value)
+        next_value = self._limit_value(next_value)
+        next_value = self._round_value(next_value)
         self.outputs.append(next_value)
 
         return next_value
@@ -37,9 +42,14 @@ class AbstractOptimizer(ABC):
         Computes the next raw size of the input generator, without limits
         """
 
-    def limit_value(self, next_value: float) -> float:
+    def _limit_value(self, next_value: float) -> float:
         if self.max_value is not None:
             next_value = min(self.max_value, next_value)
         if self.min_value is not None:
             next_value = max(self.min_value, next_value)
         return next_value
+
+    def _round_value(self, next_value: float) -> float:
+        # In this case, round_places can only be an int or literally "false", so, checking for truthiness is not
+        # correct.
+        return round(next_value, self.round_places) if self.round_places is not False else next_value

--- a/orbiteer/optimizers/ratio.py
+++ b/orbiteer/optimizers/ratio.py
@@ -15,14 +15,11 @@ class RatioOptimizer(AbstractOptimizer):
 
     def __init__(
         self,
-        goal: float,
-        first_value: float,
-        max_value: t.Optional[float] = None,
-        min_value: t.Optional[float] = None,
+        *args: t.Any,
         damper: float = 1.0,  # Should be less than 1.0 to have damping effect
+        **kwargs: t.Any,
     ) -> None:
-        # We need to specify all parent args in order for generic type checking to work
-        super().__init__(goal, first_value, max_value, min_value)
+        super().__init__(*args, **kwargs)
 
         self.damper = damper
 

--- a/tests/test_optimizers/test_ratio_optimizer.py
+++ b/tests/test_optimizers/test_ratio_optimizer.py
@@ -12,12 +12,17 @@ def simple_first() -> float:
 
 @pytest.fixture
 def simple_ro(simple_first: float) -> RatioOptimizer:
+    return RatioOptimizer(goal=100.0, first_value=simple_first, round_places=False)
+
+
+@pytest.fixture
+def rounded_ro(simple_first: float) -> RatioOptimizer:
     return RatioOptimizer(goal=100.0, first_value=simple_first)
 
 
 @pytest.fixture
 def damped_ro(simple_first: float) -> RatioOptimizer:
-    return RatioOptimizer(goal=100.0, first_value=simple_first, damper=0.5)
+    return RatioOptimizer(goal=100.0, first_value=simple_first, damper=0.5, round_places=False)
 
 
 def test_compute_at_goal_changes_nothing(simple_ro: RatioOptimizer, simple_first: float) -> None:
@@ -63,3 +68,13 @@ def test_measure_0_returns_last(simple_ro: RatioOptimizer, simple_first: float) 
     next_range = simple_ro.compute_next(0)
 
     assert next_range == simple_first
+
+
+def test_rounded_ro(rounded_ro: RatioOptimizer, simple_ro: RatioOptimizer) -> None:
+    measurement = 80
+
+    next_range_rounded = rounded_ro.compute_next(measurement)
+    next_range_raw = simple_ro.compute_next(measurement)
+
+    assert next_range_rounded == 38.0
+    assert next_range_raw == 37.5


### PR DESCRIPTION
 - Round to nearest integer value by default. Can be disabled with a literal False value.
 - Cleans up name of limiting function to be internally consistent